### PR TITLE
Update ElastiCache Serverless Configuration with Valkey and KMS Improvements


### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2024-12-08
+
+### Changed
+- Updated ElastiCache Serverless configuration to use `valkey` engine
+- Upgraded ElastiCache major engine version from `7` to `8`
+- Simplified KMS key import syntax from `aws_kms as kms` to `* as kms from 'aws-cdk-lib/aws-kms'`
+- Modified daily snapshot time from `"00:00-01:00"` to `"00:00"`
+
+### Added
+- Added TODO comment for future ElastiCache users and groups configuration
+
 ## 2024-12-07
 
 ### Added

--- a/lib/aws-elasticache-serverless-stack.ts
+++ b/lib/aws-elasticache-serverless-stack.ts
@@ -31,24 +31,29 @@ export class AwsElasticacheServerlessStack extends cdk.Stack {
       enableKeyRotation: true,
     });
 
+    // todo create user and group (CfnUser, CfnUserGroup)
+    // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-user.html
+    // https://stackoverflow.com/questions/46569432/does-redis-use-a-username-for-authentication
+    // Replaced redis with Valkey https://github.com/infiniflow/ragflow/pull/3164/files
+
     const elastiCacheServerless = new ElastiCache.CfnServerlessCache(
       this,
       `${props.resourcePrefix}-ElastiCache-Serverless`,
       {
-        engine: "redis",
+        engine: "valkey",
         serverlessCacheName: `${props.appName}-${props.deployEnvironment}`,
         securityGroupIds: [elastiCacheSecurityGroup.securityGroupId],
         subnetIds: elastiCacheSubnetIds,
         kmsKeyId: kmsKey.keyId,
         description: `${props.resourcePrefix}-ElastiCache-Serverless`,
-        majorEngineVersion: "7",
+        majorEngineVersion: "8",
         dailySnapshotTime: "00:00-01:00",
         snapshotRetentionLimit: 2,
         tags: [
           { key: 'environment', value: props.deployEnvironment },
           { key: 'project', value: props.appName },
           { key: 'owner', value: props.owner }
-        ]
+        ],
       },
     );
 

--- a/lib/aws-elasticache-serverless-stack.ts
+++ b/lib/aws-elasticache-serverless-stack.ts
@@ -3,7 +3,7 @@ import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import { Construct } from 'constructs';
 import { aws_elasticache as ElastiCache } from "aws-cdk-lib";
 import { SecurityGroup } from "aws-cdk-lib/aws-ec2";
-import { aws_kms as kms } from "aws-cdk-lib";
+import * as kms from 'aws-cdk-lib/aws-kms';
 import { AwsElasticacheServerlessStackProps } from './AwsElasticacheServerlessStackProps';
 import { parseVpcSubnetType } from '../utils/vpc-type-parser';
 
@@ -47,7 +47,7 @@ export class AwsElasticacheServerlessStack extends cdk.Stack {
         kmsKeyId: kmsKey.keyId,
         description: `${props.resourcePrefix}-ElastiCache-Serverless`,
         majorEngineVersion: "8",
-        dailySnapshotTime: "00:00-01:00",
+        dailySnapshotTime: "00:00",
         snapshotRetentionLimit: 2,
         tags: [
           { key: 'environment', value: props.deployEnvironment },


### PR DESCRIPTION
### **PR Type**
Configuration, Enhancement


___

### **PR Description**
This PR updates the AWS ElastiCache Serverless configuration with the following key changes:
- Replaced `redis` engine with `valkey` in the ElastiCache configuration
- Updated KMS key import method from `aws_kms as kms` to `* as kms from 'aws-cdk-lib/aws-kms'`
- Upgraded ElastiCache major engine version from `7` to `8`
- Modified daily snapshot time from `"00:00-01:00"` to `"00:00"`
- Added a TODO comment about creating ElastiCache users and groups

Notable improvements:
- Simplified KMS key import syntax
- Prepared for potential future user and group configuration
- Updated to the latest engine version

