### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## 2024-12-08
 
+### Added
+- Introduced `getShortEnvironmentName()` utility function to generate short environment name abbreviations
+- Enhanced ElastiCache user and user group naming with environment-specific short names
+
+### Changed
+- Updated ElastiCache resource naming conventions to incorporate environment-specific abbreviations
+- Improved resource identifier consistency across different environments
+
+## 2024-12-08
+
 ### Changed
 - Updated Redis environment variable names from `VALKEY_*` to `REDIS_*` for improved clarity
   * Renamed `VALKEY_USER_PASSWORD` to `REDIS_USER_PASSWORD`

--- a/lib/aws-elasticache-serverless-stack.ts
+++ b/lib/aws-elasticache-serverless-stack.ts
@@ -6,7 +6,7 @@ import { SecurityGroup } from "aws-cdk-lib/aws-ec2";
 import * as kms from 'aws-cdk-lib/aws-kms';
 import { AwsElasticacheServerlessStackProps } from './AwsElasticacheServerlessStackProps';
 import { parseVpcSubnetType } from '../utils/vpc-type-parser';
-import { validatePassword, validateRedisEngine, validateValkeyEngineVersion } from '../utils/check-environment-variable';
+import { getShortEnvironmentName, validatePassword, validateRedisEngine, validateValkeyEngineVersion } from '../utils/check-environment-variable';
 
 export class AwsElasticacheServerlessStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: AwsElasticacheServerlessStackProps) {
@@ -45,17 +45,18 @@ export class AwsElasticacheServerlessStack extends cdk.Stack {
       throw new Error('Unsupported Redis engine. Supported engines are valkey, redis, memcached.');
     }
 
+    const shortEnvironmentName = getShortEnvironmentName(props.deployEnvironment);
     const user = new ElastiCache.CfnUser(this, `${props.resourcePrefix}-ElastiCache-User`, {
       engine: props.redisEngine,
       noPasswordRequired: false,
-      userId: `${props.appName}-user`,
+      userId: `${props.appName}-${shortEnvironmentName}-usr`,
       userName: props.redisUserName,
       passwords: [props.redisUserPassword],
     });
 
     const userGroup = new ElastiCache.CfnUserGroup(this, `${props.resourcePrefix}-ElastiCache-User-Group`, {
       engine: props.redisEngine,
-      userGroupId: `${props.appName}-user-group`,
+      userGroupId: `${props.appName}-${shortEnvironmentName}-grp`,
       userIds: [user.ref],
     });
 

--- a/utils/check-environment-variable.ts
+++ b/utils/check-environment-variable.ts
@@ -81,3 +81,24 @@ export function validateValkeyEngineVersion(engineVersion: string): boolean {
 export function validateRedisEngine(engine: string): boolean {
     return ['valkey', 'redis', 'memcached'].includes(engine);
 }
+
+/**
+ * Gets the short environment name.
+ * @param environment - The environment to get the short name ('development' | 'staging' | 'production' | 'feature').
+ * @returns {string} - Returns the short environment name.
+ * @throws {Error} - Throws error if environment is not supported.
+ */
+export function getShortEnvironmentName(environment: string): string {
+    const envMap: Record<string, string> = {
+        'development': 'dev',
+        'staging': 'stg',
+        'production': 'prd',
+        'feature': 'futr'
+    };
+
+    if (!envMap[environment]) {
+        throw new Error(`Unsupported environment: ${environment}`);
+    }
+
+    return envMap[environment];
+}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **PR Description**
This PR introduces improvements to the AWS ElastiCache Serverless stack configuration:
- Added a new `getShortEnvironmentName()` utility function to generate short environment name abbreviations
- Enhanced user and user group naming conventions by incorporating environment-specific short names
- Improved naming consistency for ElastiCache resources across different environments

Key changes:
- Created `getShortEnvironmentName()` function in `utils/check-environment-variable.ts`
  - Supports mapping full environment names to short abbreviations
  - Handles 'development', 'staging', 'production', and 'feature' environments
- Updated ElastiCache user and user group naming in `aws-elasticache-serverless-stack.ts`
  - Incorporated short environment names into resource identifiers
  - Example: From `app-user` to `app-dev-usr` for development environment

