### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## 2024-12-09
 
+### Changed
+- Renamed `validateValkeyEngineVersion` to `validateRedisEngineVersion` for improved clarity
+- Updated ElastiCache user group ID to use a more consistent naming convention
+- Added removal policies to key AWS resources including security group, KMS key, ElastiCache user, and user group
+
+### Updated
+- Bumped package version from `0.1.0` to `0.1.1`
+- Updated `cdk-nag` dependency from `2.34.18` to `2.34.20`
+
+### Added
+- Exported KMS key ID and ARN as CloudFormation outputs
+
+## 2024-12-09
+
 ### Added
 - Added comprehensive property and class descriptions for `AwsElasticacheServerlessStack` and `AwsElasticacheServerlessStackProps`
 - Introduced `shortDeployEnvironment` to optimize resource naming

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "aws-elasticache-serverless",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-elasticache-serverless",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "aws-cdk-lib": "2.172.0",
-        "cdk-nag": "^2.34.18",
+        "cdk-nag": "^2.34.20",
         "constructs": "^10.4.2",
         "dotenv": "^16.4.7"
       },
@@ -1894,9 +1894,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/cdk-nag": {
-      "version": "2.34.18",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.34.18.tgz",
-      "integrity": "sha512-Sg6eQ6C+WGTutdy5zw80tdevVZDcK50zijz7DFAOpb6gFeTl2/YsPH/YgQFMuX3Au/RfHRhhQadkh2GUdSpAxA==",
+      "version": "2.34.20",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.34.20.tgz",
+      "integrity": "sha512-yM8lWlYGFy/wQO5JHShvEhgaSTLkT7LXbuv0FkfOzxZ28+lPfCZ92wo5uFiJMY4VwXiNKqGVNWZz9t34Skjr6w==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "aws-cdk-lib": "^2.156.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-elasticache-serverless",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "bin": {
     "aws-elasticache-serverless": "bin/aws-elasticache-serverless.js"
   },
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "2.172.0",
-    "cdk-nag": "^2.34.18",
+    "cdk-nag": "^2.34.20",
     "constructs": "^10.4.2",
     "dotenv": "^16.4.7"
   },

--- a/utils/check-environment-variable.ts
+++ b/utils/check-environment-variable.ts
@@ -68,7 +68,7 @@ export function validatePassword(password: string): boolean {
  * @param engineVersion - The engine version to validate.
  * @returns {boolean} - Returns true if the engine version is supported, otherwise false.
  */
-export function validateValkeyEngineVersion(engineVersion: string): boolean {
+export function validateRedisEngineVersion(engineVersion: string): boolean {
     return ['7', '8'].includes(engineVersion);
 }
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Dependencies


___

### **PR Description**
This PR introduces several improvements to the AWS ElastiCache Serverless stack:

- Renamed `validateValkeyEngineVersion` to `validateRedisEngineVersion` for better clarity
- Added removal policies to key AWS resources (security group, KMS key, ElastiCache user, and user group)
- Exported KMS key ID and ARN as CloudFormation outputs
- Updated `cdk-nag` dependency from `2.34.18` to `2.34.20`
- Bumped package version from `0.1.0` to `0.1.1`
- Corrected the ElastiCache user group ID to use a more consistent naming convention

Key changes focus on improving resource management and providing additional exported information for the ElastiCache Serverless infrastructure.

