### PR TITLE
Export Redis Serverless Endpoint Details and Update Dependencies


### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 2024-12-13
+
+### Added
+- Exported Redis serverless endpoint address and port as CloudFormation outputs
+
+### Updated
+- Bumped package version from `0.1.1` to `0.1.3`
+- Updated dependencies:
+  * Upgraded `aws-cdk` from `2.172.0` to `2.173.0`
+  * Upgraded `aws-cdk-lib` from `2.172.0` to `2.173.0`
+  * Upgraded `@types/node` from `22.10.1` to `22.10.2`
+  * Upgraded `cdk-nag` from `2.34.20` to `2.34.23
+
 ## 2024-12-09
 
 ### Changed

--- a/lib/aws-elasticache-serverless-stack.ts
+++ b/lib/aws-elasticache-serverless-stack.ts
@@ -153,5 +153,20 @@ export class AwsElasticacheServerlessStack extends cdk.Stack {
       exportName: `${props.resourcePrefix}-KMS-Key-Arn`,
       description: `${props.resourcePrefix}-KMS-Key-Arn`,
     });
+
+    const endpointAddress = elastiCacheServerless.attrEndpointAddress;
+    const endpointPort = elastiCacheServerless.attrEndpointPort;
+
+    new cdk.CfnOutput(this, `${props.resourcePrefix}-ElastiCache-Serverless-Endpoint-Address`, {
+      value: endpointAddress,
+      exportName: `${props.resourcePrefix}-ElastiCache-Serverless-Endpoint-Address`,
+      description: `${props.resourcePrefix}-ElastiCache-Serverless-Endpoint-Address`,
+    });
+
+    new cdk.CfnOutput(this, `${props.resourcePrefix}-ElastiCache-Serverless-Endpoint-Port`, {
+      value: endpointPort,
+      exportName: `${props.resourcePrefix}-ElastiCache-Serverless-Endpoint-Port`,
+      description: `${props.resourcePrefix}-ElastiCache-Serverless-Endpoint-Port`,
+    });
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "aws-elasticache-serverless",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-elasticache-serverless",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "aws-cdk-lib": "2.172.0",
-        "cdk-nag": "^2.34.20",
+        "cdk-nag": "^2.34.23",
         "constructs": "^10.4.2",
         "dotenv": "^16.4.7"
       },
@@ -19,7 +19,7 @@
       "devDependencies": {
         "@tsconfig/node22": "^22.0.0",
         "@types/jest": "^29.5.14",
-        "@types/node": "22.10.1",
+        "@types/node": "22.10.2",
         "@types/source-map-support": "^0.5.10",
         "aws-cdk": "2.172.0",
         "jest": "^29.7.0",
@@ -1136,9 +1136,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.10.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
-      "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
+      "version": "22.10.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
+      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1894,9 +1894,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/cdk-nag": {
-      "version": "2.34.20",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.34.20.tgz",
-      "integrity": "sha512-yM8lWlYGFy/wQO5JHShvEhgaSTLkT7LXbuv0FkfOzxZ28+lPfCZ92wo5uFiJMY4VwXiNKqGVNWZz9t34Skjr6w==",
+      "version": "2.34.23",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.34.23.tgz",
+      "integrity": "sha512-TCvQy5uCk1QHek7UhbmFh4Uk2HveXyuQ6jfUC0ZfW5HgAMhv8+6lTY56Jq09/rm0csKDzWnMpGGAXjgLW6rg0A==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "aws-cdk-lib": "^2.156.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "aws-elasticache-serverless",
       "version": "0.1.2",
       "dependencies": {
-        "aws-cdk-lib": "2.172.0",
+        "aws-cdk-lib": "2.173.0",
         "cdk-nag": "^2.34.23",
         "constructs": "^10.4.2",
         "dotenv": "^16.4.7"
@@ -21,15 +21,15 @@
         "@types/jest": "^29.5.14",
         "@types/node": "22.10.2",
         "@types/source-map-support": "^0.5.10",
-        "aws-cdk": "2.172.0",
+        "aws-cdk": "2.173.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
         "typescript": "~5.7.2"
       },
       "peerDependencies": {
-        "aws-cdk": "2.172.0",
-        "aws-cdk-lib": "2.172.0",
+        "aws-cdk": "2.173.0",
+        "aws-cdk-lib": "2.173.0",
         "constructs": "^10.4.2"
       }
     },
@@ -1286,9 +1286,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.172.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.172.0.tgz",
-      "integrity": "sha512-kacztcAl12F6zlBqKCuzCZmj4vrbMhzgDAxBB4T7fXR2amQyuu6W0nWcGWWvASXeBJcw2DJ6ulpfV4wuc9dksw==",
+      "version": "2.173.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.173.0.tgz",
+      "integrity": "sha512-riRGKSo5dzB0MSbdkZwXRC2t//dI220bgEUfVISilcEafBKj+BPzFBd/eNKuP/dEaS31njkCwtYrS7V7/lV4hQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1302,9 +1302,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.172.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.172.0.tgz",
-      "integrity": "sha512-SbFn2FyKhsHQpS7M3qeMWnRKtBHELkY3rmejk07cPlJ/BCJk/af8eKyeiNEEB0AZSfIeP4ImZCLNy9JS34mlPw==",
+      "version": "2.173.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.173.0.tgz",
+      "integrity": "sha512-Da1JUwG8eL+chRSB+c2I4dRf54DWe/wmWKj9CBthNdsE9XCB8odyEcMpmgBC+R160o7ioYY2DBsAaKIIRa9XQw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-elasticache-serverless",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-elasticache-serverless",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "aws-cdk-lib": "2.173.0",
         "cdk-nag": "^2.34.23",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-elasticache-serverless",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "bin": {
     "aws-elasticache-serverless": "bin/aws-elasticache-serverless.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-elasticache-serverless",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "bin": {
     "aws-elasticache-serverless": "bin/aws-elasticache-serverless.js"
   },
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@tsconfig/node22": "^22.0.0",
     "@types/jest": "^29.5.14",
-    "@types/node": "22.10.1",
+    "@types/node": "22.10.2",
     "@types/source-map-support": "^0.5.10",
     "aws-cdk": "2.172.0",
     "jest": "^29.7.0",
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "2.172.0",
-    "cdk-nag": "^2.34.20",
+    "cdk-nag": "^2.34.23",
     "constructs": "^10.4.2",
     "dotenv": "^16.4.7"
   },

--- a/package.json
+++ b/package.json
@@ -15,21 +15,21 @@
     "@types/jest": "^29.5.14",
     "@types/node": "22.10.2",
     "@types/source-map-support": "^0.5.10",
-    "aws-cdk": "2.172.0",
+    "aws-cdk": "2.173.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "typescript": "~5.7.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.172.0",
+    "aws-cdk-lib": "2.173.0",
     "cdk-nag": "^2.34.23",
     "constructs": "^10.4.2",
     "dotenv": "^16.4.7"
   },
   "peerDependencies": {
-    "aws-cdk": "2.172.0",
-    "aws-cdk-lib": "2.172.0",
+    "aws-cdk": "2.173.0",
+    "aws-cdk-lib": "2.173.0",
     "constructs": "^10.4.2"
   }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Dependencies


___

### **PR Description**
- Exported Redis serverless endpoint address and port as CloudFormation outputs in `lib/aws-elasticache-serverless-stack.ts`
- Updated project version from `0.1.1` to `0.1.3`
- Updated dependencies:
  * Upgraded `aws-cdk` from `2.172.0` to `2.173.0`
  * Upgraded `aws-cdk-lib` from `2.172.0` to `2.173.0`
  * Upgraded `@types/node` from `22.10.1` to `22.10.2`
  * Upgraded `cdk-nag` from `2.34.20` to `2.34.23`

