### PR TITLE
Disable Default Outbound Traffic for ElastiCache Security Group


### DIFF
--- a/lib/aws-elasticache-serverless-stack.ts
+++ b/lib/aws-elasticache-serverless-stack.ts
@@ -54,6 +54,7 @@ export class AwsElasticacheServerlessStack extends cdk.Stack {
 
     const elastiCacheSecurityGroup = new SecurityGroup(this, `${props.resourcePrefix}-ElastiCache-Security-Group`, {
       vpc,
+      allowAllOutbound: false,
       description: `${props.resourcePrefix}-ElastiCache-Security-Group`,
     });
     elastiCacheSecurityGroup.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);

--- a/lib/aws-elasticache-serverless-stack.ts
+++ b/lib/aws-elasticache-serverless-stack.ts
@@ -52,12 +52,9 @@ export class AwsElasticacheServerlessStack extends cdk.Stack {
       vpcId: props.vpcId,
     });
 
-    const vpcSubnetType = parseVpcSubnetType(props.vpcSubnetType);
-
     const elastiCacheSecurityGroup = new SecurityGroup(this, `${props.resourcePrefix}-ElastiCache-Security-Group`, {
       vpc,
       description: `${props.resourcePrefix}-ElastiCache-Security-Group`,
-      allowAllOutbound: true,
     });
     elastiCacheSecurityGroup.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);
 


### PR DESCRIPTION
### **PR Type**
Configuration


___

### **PR Description**
- Disabled default outbound traffic for the ElastiCache Security Group in AWS CDK stack
- Modified `allowAllOutbound` parameter from `true` to `false` in `elastiCacheSecurityGroup` configuration
- Removed unused `parseVpcSubnetType` import/usage

