### PR TITLE
Refactor AWS CDK stack and update environment variable configuration


### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@ APP_NAME=ow-redis-serverless
 CDK_DEPLOY_REGION=ap-southeast-1
 ENVIRONMENT=development
 
-OWNER=OPENWORKSPACE
+OWNER=OpenWorkspace-o1
 
 VPC_ID=vpc-xxxxxxxx
 VPC_SUBNET_TYPE=PRIVATE_ISOLATED

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2024-12-18
+
+### Changed
+- Removed redundant import of `parseVpcSubnetType` from AWS ElastiCache Serverless stack
+- Updated `OWNER` environment variable in `.env.example` from `OPENWORKSPACE` to `OpenWorkspace-o1`
+
+### Improved
+- Enhanced clarity and maintainability of AWS CDK stack for ElastiCache Serverless deployment
+
 ## 2024-12-14
 
 ### Added

--- a/lib/aws-elasticache-serverless-stack.ts
+++ b/lib/aws-elasticache-serverless-stack.ts
@@ -5,7 +5,6 @@ import { aws_elasticache as ElastiCache } from "aws-cdk-lib";
 import { SecurityGroup } from "aws-cdk-lib/aws-ec2";
 import * as kms from 'aws-cdk-lib/aws-kms';
 import { AwsElasticacheServerlessStackProps } from './AwsElasticacheServerlessStackProps';
-import { parseVpcSubnetType } from '../utils/vpc-type-parser';
 import { validatePassword, validateRedisEngine, validateRedisEngineVersion } from '../utils/check-environment-variable';
 
 /**


### PR DESCRIPTION
### **PR Type**
Configuration, Enhancement


___

### **PR Description**
- Removed the redundant import of `parseVpcSubnetType` from `lib/aws-elasticache-serverless-stack.ts`.
- Updated the `OWNER` environment variable in `.env.example` from `OPENWORKSPACE` to `OpenWorkspace-o1`.
- Improved the clarity and maintainability of the AWS CDK stack for deploying an Amazon ElastiCache Serverless instance.

