### PR TITLE
Add KMS key rotation and update AWS CDK dependencies


### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Updated
 - Upgraded `aws-cdk` and `aws-cdk-lib` dependencies to version `2.173.4`
 - Bumped project version from `0.1.4` to `0.1.5`
-- Updated `@types/node` from `22.10.2` to `22.10.3
+- Updated `@types/node` from `22.10.2` to `22.10.3`
 
 ## 2024-12-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2025-01-02 [*][https://github.com/OpenWorkspace-o1/aws-elasticache-serverless/pull/25]
+
+### Added
+- Enabled KMS key rotation with a `rotationPeriod` of 30 days
+
+### Updated
+- Upgraded `aws-cdk` and `aws-cdk-lib` dependencies to version `2.173.4`
+- Bumped project version from `0.1.4` to `0.1.5`
+- Updated `@types/node` from `22.10.2` to `22.10.3
+
 ## 2024-12-18
 
 ### Changed

--- a/lib/aws-elasticache-serverless-stack.ts
+++ b/lib/aws-elasticache-serverless-stack.ts
@@ -59,9 +59,11 @@ export class AwsElasticacheServerlessStack extends cdk.Stack {
     elastiCacheSecurityGroup.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);
 
     const kmsKey = new kms.Key(this, `${props.resourcePrefix}-KMS-Key`, {
-      description: `${props.resourcePrefix}-KMS-Key`,
+      enabled: true,
       enableKeyRotation: true,
+      description: `${props.resourcePrefix}-KMS-Key`,
       removalPolicy: cdk.RemovalPolicy.DESTROY,
+      rotationPeriod: cdk.Duration.days(30),
     });
 
     // todo create user and group (CfnUser, CfnUserGroup)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-elasticache-serverless",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-elasticache-serverless",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "aws-cdk-lib": "2.173.4",
         "cdk-nag": "^2.34.23",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "aws-elasticache-serverless",
       "version": "0.1.4",
       "dependencies": {
-        "aws-cdk-lib": "2.173.2",
+        "aws-cdk-lib": "2.173.4",
         "cdk-nag": "^2.34.23",
         "constructs": "^10.4.2",
         "dotenv": "^16.4.7"
@@ -19,17 +19,17 @@
       "devDependencies": {
         "@tsconfig/node22": "^22.0.0",
         "@types/jest": "^29.5.14",
-        "@types/node": "22.10.2",
+        "@types/node": "22.10.3",
         "@types/source-map-support": "^0.5.10",
-        "aws-cdk": "2.173.2",
+        "aws-cdk": "2.173.4",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
         "typescript": "~5.7.2"
       },
       "peerDependencies": {
-        "aws-cdk": "2.173.2",
-        "aws-cdk-lib": "2.173.2",
+        "aws-cdk": "2.173.4",
+        "aws-cdk-lib": "2.173.4",
         "constructs": "^10.4.2"
       }
     },
@@ -1136,9 +1136,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.10.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
-      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+      "version": "22.10.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.3.tgz",
+      "integrity": "sha512-DifAyw4BkrufCILvD3ucnuN8eydUfc/C1GlyrnI+LK6543w5/L3VeVgf05o3B4fqSXP1dKYLOZsKfutpxPzZrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1286,9 +1286,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.173.2",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.173.2.tgz",
-      "integrity": "sha512-qyMU4FoRJdZDUpsOBqyRBALBjf5A2N/MaHKX9iJUkbTET+d+nR07x3ai4TcEES+8pqPFHMTKpQMRDXs9Py/15w==",
+      "version": "2.173.4",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.173.4.tgz",
+      "integrity": "sha512-zgs3xU28VEKIwHwJHu0ZHeoEmwLGnHS2jPCMc2MsIMZu+a7CKyE77Tw6LwJkuuB96BQyqr6xJB3SbeWjXmcFhQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1302,9 +1302,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.173.2",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.173.2.tgz",
-      "integrity": "sha512-cL9+z8Pl3VZGoO7BwdsrFAOeud/vSl3at7OvmhihbNprMN15XuFUx/rViAU5OI1m92NbV4NBzYSLbSeCwYLNyw==",
+      "version": "2.173.4",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.173.4.tgz",
+      "integrity": "sha512-0reN94TzkWmyVZDDBlYB4qzJUig8wTHEe82YLHlWRUhrU78fT+drVGUr+lYZwwETaZ+8fLdCOl9ULvFNq7iczQ==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",

--- a/package.json
+++ b/package.json
@@ -13,23 +13,23 @@
   "devDependencies": {
     "@tsconfig/node22": "^22.0.0",
     "@types/jest": "^29.5.14",
-    "@types/node": "22.10.2",
+    "@types/node": "22.10.3",
     "@types/source-map-support": "^0.5.10",
-    "aws-cdk": "2.173.2",
+    "aws-cdk": "2.173.4",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "typescript": "~5.7.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.173.2",
+    "aws-cdk-lib": "2.173.4",
     "cdk-nag": "^2.34.23",
     "constructs": "^10.4.2",
     "dotenv": "^16.4.7"
   },
   "peerDependencies": {
-    "aws-cdk": "2.173.2",
-    "aws-cdk-lib": "2.173.2",
+    "aws-cdk": "2.173.4",
+    "aws-cdk-lib": "2.173.4",
     "constructs": "^10.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-elasticache-serverless",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "bin": {
     "aws-elasticache-serverless": "bin/aws-elasticache-serverless.js"
   },


### PR DESCRIPTION
### **PR Type**
Enhancement, Dependencies

___

### **PR Description**
- Added `rotationPeriod` of 30 days for `kms.Key`.

- Enabled `kms.Key` with `enableKeyRotation` set to true.

- Updated `aws-cdk` and `aws-cdk-lib` dependencies to version `2.173.4`.

- Incremented project version from `0.1.4` to `0.1.5`.
