### PR TITLE
update output

### DIFF
--- a/lib/aws-elasticache-serverless-stack.ts
+++ b/lib/aws-elasticache-serverless-stack.ts
@@ -152,26 +152,26 @@ export class AwsElasticacheServerlessStack extends cdk.Stack {
 
     const elastiCacheServerlessEndpoint = elastiCacheServerless.endpoint as ElastiCache.CfnServerlessCache.EndpointProperty;
     new cdk.CfnOutput(this, `${props.resourcePrefix}-ElastiCache-Serverless-Endpoint-Address`, {
-      value: elastiCacheServerlessEndpoint.address || '',
+      value: elastiCacheServerlessEndpoint?.address || '',
       exportName: `${props.resourcePrefix}-ElastiCache-Serverless-Endpoint`,
       description: `${props.resourcePrefix}-ElastiCache-Serverless-Endpoint`,
     });
 
     new cdk.CfnOutput(this, `${props.resourcePrefix}-ElastiCache-Serverless-Endpoint-Port`, {
-      value: elastiCacheServerlessEndpoint.port || '',
+      value: elastiCacheServerlessEndpoint?.port || '',
       exportName: `${props.resourcePrefix}-ElastiCache-Serverless-Endpoint-Port`,
       description: `${props.resourcePrefix}-ElastiCache-Serverless-Endpoint-Port`,
     });
 
     const elastiCacheServerlessReaderEndpoint = elastiCacheServerless.readerEndpoint as ElastiCache.CfnServerlessCache.EndpointProperty;
     new cdk.CfnOutput(this, `${props.resourcePrefix}-ElastiCache-Serverless-Reader-Endpoint-Address`, {
-      value: elastiCacheServerlessReaderEndpoint.address || '',
+      value: elastiCacheServerlessReaderEndpoint?.address || '',
       exportName: `${props.resourcePrefix}-ElastiCache-Serverless-Reader-Endpoint-Address`,
       description: `${props.resourcePrefix}-ElastiCache-Serverless-Reader-Endpoint-Address`,
     });
 
     new cdk.CfnOutput(this, `${props.resourcePrefix}-ElastiCache-Serverless-Reader-Endpoint-Port`, {
-      value: elastiCacheServerlessReaderEndpoint.port || '',
+      value: elastiCacheServerlessReaderEndpoint?.port || '',
       exportName: `${props.resourcePrefix}-ElastiCache-Serverless-Reader-Endpoint-Port`,
       description: `${props.resourcePrefix}-ElastiCache-Serverless-Reader-Endpoint-Port`,
     });

--- a/lib/aws-elasticache-serverless-stack.ts
+++ b/lib/aws-elasticache-serverless-stack.ts
@@ -150,19 +150,38 @@ export class AwsElasticacheServerlessStack extends cdk.Stack {
       description: `${props.resourcePrefix}-KMS-Key-Arn`,
     });
 
-    const endpointAddress = elastiCacheServerless.attrEndpointAddress;
-    const endpointPort = elastiCacheServerless.attrEndpointPort;
-
+    const elastiCacheServerlessEndpoint = elastiCacheServerless.endpoint as ElastiCache.CfnServerlessCache.EndpointProperty;
     new cdk.CfnOutput(this, `${props.resourcePrefix}-ElastiCache-Serverless-Endpoint-Address`, {
-      value: endpointAddress,
-      exportName: `${props.resourcePrefix}-ElastiCache-Serverless-Endpoint-Address`,
-      description: `${props.resourcePrefix}-ElastiCache-Serverless-Endpoint-Address`,
+      value: elastiCacheServerlessEndpoint.address || '',
+      exportName: `${props.resourcePrefix}-ElastiCache-Serverless-Endpoint`,
+      description: `${props.resourcePrefix}-ElastiCache-Serverless-Endpoint`,
     });
 
     new cdk.CfnOutput(this, `${props.resourcePrefix}-ElastiCache-Serverless-Endpoint-Port`, {
-      value: endpointPort,
+      value: elastiCacheServerlessEndpoint.port || '',
       exportName: `${props.resourcePrefix}-ElastiCache-Serverless-Endpoint-Port`,
       description: `${props.resourcePrefix}-ElastiCache-Serverless-Endpoint-Port`,
+    });
+
+    const elastiCacheServerlessReaderEndpoint = elastiCacheServerless.readerEndpoint as ElastiCache.CfnServerlessCache.EndpointProperty;
+    new cdk.CfnOutput(this, `${props.resourcePrefix}-ElastiCache-Serverless-Reader-Endpoint-Address`, {
+      value: elastiCacheServerlessReaderEndpoint.address || '',
+      exportName: `${props.resourcePrefix}-ElastiCache-Serverless-Reader-Endpoint-Address`,
+      description: `${props.resourcePrefix}-ElastiCache-Serverless-Reader-Endpoint-Address`,
+    });
+
+    new cdk.CfnOutput(this, `${props.resourcePrefix}-ElastiCache-Serverless-Reader-Endpoint-Port`, {
+      value: elastiCacheServerlessReaderEndpoint.port || '',
+      exportName: `${props.resourcePrefix}-ElastiCache-Serverless-Reader-Endpoint-Port`,
+      description: `${props.resourcePrefix}-ElastiCache-Serverless-Reader-Endpoint-Port`,
+    });
+
+
+    const elastiCacheServerlessARN = elastiCacheServerless.attrArn;
+    new cdk.CfnOutput(this, `${props.resourcePrefix}-ElastiCache-Serverless-ARN`, {
+      value: elastiCacheServerlessARN,
+      exportName: `${props.resourcePrefix}-ElastiCache-Serverless-ARN`,
+      description: `${props.resourcePrefix}-ElastiCache-Serverless-ARN`,
     });
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "aws-elasticache-serverless",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-elasticache-serverless",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "aws-cdk-lib": "2.202.0",
-        "cdk-nag": "^2.36.23",
+        "cdk-nag": "^2.36.24",
         "constructs": "^10.4.2",
         "dotenv": "^16.5.0"
       },
@@ -2301,9 +2301,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/cdk-nag": {
-      "version": "2.36.23",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.36.23.tgz",
-      "integrity": "sha512-1KLsCHZ8fYgiBIneMKyEq67DH/OfEXYZ5mYasmXdha4bRlJvgllL+XpTkYSSy0Kn43g2Lv92d1lhkOd9xgnMOQ==",
+      "version": "2.36.24",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.36.24.tgz",
+      "integrity": "sha512-swrTkaUIgVHINIuoVM766lUMUHrJWMHG2aknAfz1jroTiDHe+7myYKdyIwJoelzcHmPsJzCiDWFD3j0duGCP3g==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "aws-cdk-lib": "^2.156.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-elasticache-serverless",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "bin": {
     "aws-elasticache-serverless": "bin/aws-elasticache-serverless.js"
   },
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "2.202.0",
-    "cdk-nag": "^2.36.23",
+    "cdk-nag": "^2.36.24",
     "constructs": "^10.4.2",
     "dotenv": "^16.5.0"
   },


### PR DESCRIPTION
### **PR Type**
Enhancement, Configuration

___

### **PR Description**
- Added reader endpoint outputs for ElastiCache Serverless.

- Updated endpoint handling with null checks.

- Added ARN output for ElastiCache Serverless.

- Updated `cdk-nag` dependency to `2.36.24`.
